### PR TITLE
Raise an error when trying to search with a regexp

### DIFF
--- a/lib/mongoid-encrypted-fields/fields/encrypted_field.rb
+++ b/lib/mongoid-encrypted-fields/fields/encrypted_field.rb
@@ -40,6 +40,8 @@ module Mongoid
             object.mongoize
           when object.blank? || is_encrypted?(object)
             object
+          when object.is_a?(Regexp)
+            raise NotImplementedError.new("Searching is only possible when using equality")            
           else
             convert(object).mongoize
         end


### PR DESCRIPTION
This gives the developer a pointer when searching goes wrong.
Instead of raising the error: TypeError: can't convert Regexp into String
we now raise: NotImplementedError: Searching is only possible when using equality
