### PR TITLE
Remove deprecated Validator#setup method

### DIFF
--- a/.gemfiles/Gemfile.mongoid4_rails42
+++ b/.gemfiles/Gemfile.mongoid4_rails42
@@ -3,8 +3,8 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', '4.0.0'
-gem "actionpack",  "~> 4.2.0.beta1"
-gem "activemodel", "~> 4.2.0.beta1"
+gem "actionpack",  "~> 4.2.0"
+gem "activemodel", "~> 4.2.0"
 
 group :test do
   gem 'coveralls', require: false

--- a/lib/mongoid-encrypted-fields/mongoid4/validatable/uniqueness.rb
+++ b/lib/mongoid-encrypted-fields/mongoid4/validatable/uniqueness.rb
@@ -16,10 +16,6 @@ module Mongoid
         super
       end
 
-      def setup(klass)
-        @klass = klass
-      end
-
       def check_validity!
         return if case_sensitive?
         return unless klass


### PR DESCRIPTION
Hello!

Thanks for making this gem, it's really helpful.

I'm still seeing the deprecation warning from #17 but this patch takes care of it. If the validator object has a method called `setup` at all, it will emit this deprecation warning ([relevant line](https://github.com/rails/rails/commit/7d84c3a2f7ede0e8d04540e9c0640de7378e9b3a#diff-ece661173618f9d091d7920351116fc9R128)).

Is it safe to just delete this method? I'm not sure. The tests pass locally, but I'm not sure if they'll pass on Travis with the full matrix of versions.

For context, here are the versions I'm using where I see the deprecation warning:

* Rails 4.1.9
* Mongoid 4.0.0
* Mongoid Encrypted Fields 1.3.2

The deprecation warning can be seen in [the most recent Travis build as well](https://travis-ci.org/KoanHealth/mongoid-encrypted-fields/jobs/41413960).