### PR TITLE
Support mongoid 5. But other problems remain.

### DIFF
--- a/lib/mongoid-encrypted-fields.rb
+++ b/lib/mongoid-encrypted-fields.rb
@@ -26,7 +26,7 @@ end
 case ::Mongoid::EncryptedFields.mongoid_major_version
   when 3
     require 'mongoid-encrypted-fields/mongoid3/validations/uniqueness'
-  when 4
+  when 4,5
     require 'mongoid-encrypted-fields/mongoid4/validatable/uniqueness'
   else
     raise "Unsupported version of Mongoid: #{::Mongoid::VERSION::MAJOR}"


### PR DESCRIPTION
Quick and dirty change to support Mongoid 5. Tests pass on ruby 2.0.0 but there are deprecation warnings for rspec.