### PR TITLE
Mongoid 6 Support

### DIFF
--- a/.gemfiles/Gemfile.mongoid3
+++ b/.gemfiles/Gemfile.mongoid3
@@ -3,9 +3,10 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', '~> 3'
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.gemfiles/Gemfile.mongoid4
+++ b/.gemfiles/Gemfile.mongoid4
@@ -4,8 +4,10 @@ gemspec path: '..'
 gem 'rake'
 gem 'mongoid', '4.0.0'
 
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
+
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.gemfiles/Gemfile.mongoid4_rails41
+++ b/.gemfiles/Gemfile.mongoid4_rails41
@@ -3,11 +3,12 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', '4.0.0'
-gem "actionpack",  "~> 4.1.0"
-gem "activemodel", "~> 4.1.0"
+gem 'actionpack',  '~> 4.1.0'
+gem 'activemodel', '~> 4.1.0'
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.gemfiles/Gemfile.mongoid4_rails42
+++ b/.gemfiles/Gemfile.mongoid4_rails42
@@ -3,11 +3,12 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', '4.0.0'
-gem "actionpack",  "~> 4.2.0"
-gem "activemodel", "~> 4.2.0"
+gem 'actionpack',  '~> 4.2.0'
+gem 'activemodel', '~> 4.2.0'
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.gemfiles/Gemfile.mongoid5_rails4
+++ b/.gemfiles/Gemfile.mongoid5_rails4
@@ -3,11 +3,12 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', '< 6'
-gem "actionpack",  "< 5"
-gem "activemodel", "< 5"
+gem 'actionpack',  '< 5'
+gem 'activemodel', '< 5'
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.gemfiles/Gemfile.mongoid6_rails5
+++ b/.gemfiles/Gemfile.mongoid6_rails5
@@ -3,11 +3,12 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', '>= 6.0.0.rc0', '< 7'
-gem "actionpack",  "< 6"
-gem "activemodel", "< 6"
+gem 'actionpack',  '< 6'
+gem 'activemodel', '< 6'
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.gemfiles/Gemfile.mongoid6_rails5
+++ b/.gemfiles/Gemfile.mongoid6_rails5
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'rake'
+gem 'mongoid', '>= 6.0.0.rc0', '< 7'
+gem "actionpack",  "< 6"
+gem "activemodel", "< 6"
+
+group :test do
+  gem 'coveralls', require: false
+  gem 'encrypted_strings', '~> 0.3'
+  gem 'gibberish', '~> 1.2.2'
+  gem 'rspec', '~> 2.13'
+  gem 'simplecov', require: false
+end

--- a/.gemfiles/Gemfile.mongoid_head
+++ b/.gemfiles/Gemfile.mongoid_head
@@ -3,9 +3,10 @@ gemspec path: '..'
 
 gem 'rake'
 gem 'mongoid', github: 'mongoid/mongoid'
+gem 'json', '< 2' if RUBY_VERSION < '2.0'
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0'), require: false
   gem 'encrypted_strings', '~> 0.3'
   gem 'gibberish', '~> 1.2.2'
   gem 'rspec', '~> 2.13'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,13 @@ gemfile:
   - .gemfiles/Gemfile.mongoid4_rails42
   - .gemfiles/Gemfile.mongoid5_rails4
   - .gemfiles/Gemfile.mongoid_head
+matrix:
+  include:
+    - rvm: 2.3.1
+      gemfile: .gemfiles/Gemfile.mongoid6_rails5
 notifications:
   recipients:
     - jerry.clinesmith@koanhealth.com
 services:
   - mongodb
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-matrix:
-  allow_failures:
-    - gemfile: .gemfiles/Gemfile.mongoid_head
+before_install:
+  - gem install bundler
 gemfile:
   - .gemfiles/Gemfile.mongoid3
   - .gemfiles/Gemfile.mongoid4
@@ -15,6 +14,8 @@ gemfile:
   - .gemfiles/Gemfile.mongoid5_rails4
   - .gemfiles/Gemfile.mongoid_head
 matrix:
+  allow_failures:
+    - gemfile: .gemfiles/Gemfile.mongoid_head
   include:
     - rvm: 2.3.1
       gemfile: .gemfiles/Gemfile.mongoid6_rails5

--- a/lib/mongoid-encrypted-fields.rb
+++ b/lib/mongoid-encrypted-fields.rb
@@ -26,7 +26,7 @@ end
 case ::Mongoid::EncryptedFields.mongoid_major_version
   when 3
     require 'mongoid-encrypted-fields/mongoid3/validations/uniqueness'
-  when 4, 5
+  when 4, 5, 6
     require 'mongoid-encrypted-fields/mongoid4/validatable/uniqueness'
   else
     raise "Unsupported version of Mongoid: #{::Mongoid::VERSION::MAJOR}"

--- a/mongoid-encrypted-fields.gemspec
+++ b/mongoid-encrypted-fields.gemspec
@@ -21,11 +21,12 @@ Gem::Specification.new do |gem|
   gem.require_path  = 'lib'
 
   gem.add_dependency 'mongoid', '>= 3'
+  gem.add_dependency 'json', '< 2' if RUBY_VERSION < '2.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'gibberish', '~> 1.2.2'
   gem.add_development_dependency 'encrypted_strings', '~> 0.3'
-  gem.add_development_dependency 'coveralls'
+  gem.add_development_dependency 'coveralls', ('<= 0.8.14' if RUBY_VERSION < '2.0')
   gem.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
There weren't any breaking changes, just a small version logic change was necessary. All gemfiles needed some `RUBY_VERSION` checks for certain dependencies to maintain support for 1.9.3.

Also, I'd be willing to maintain this gem. We use this in production at hund.io.