### PR TITLE
Add unsearchable encrypted field types to use unique salt

### DIFF
--- a/examples/gibberish_cipher.rb
+++ b/examples/gibberish_cipher.rb
@@ -4,7 +4,7 @@ require 'gibberish/aes'
 # so Searching for encrypted field will work
 class GibberishCipher
 
-  def initialize(password, salt)
+  def initialize(password, salt = nil)
     if defined?(Gibberish::AES::CBC)
       @cipher = Gibberish::AES::CBC.new(password)
     else
@@ -14,7 +14,7 @@ class GibberishCipher
   end
 
   def encrypt(data)
-    @cipher.encrypt(data, salt: @salt)
+    @cipher.encrypt(data, salt: (@salt || SecureRandom.base64))
   end
 
   def decrypt(data)

--- a/lib/mongoid-encrypted-fields.rb
+++ b/lib/mongoid-encrypted-fields.rb
@@ -6,13 +6,19 @@ require 'mongoid-encrypted-fields/fields/encrypted_string'
 require 'mongoid-encrypted-fields/fields/encrypted_date'
 require 'mongoid-encrypted-fields/fields/encrypted_date_time'
 require 'mongoid-encrypted-fields/fields/encrypted_time'
+require 'mongoid-encrypted-fields/fields/unsearchable_encrypted_field'
+require 'mongoid-encrypted-fields/fields/unsearchable_encrypted_hash'
+require 'mongoid-encrypted-fields/fields/unsearchable_encrypted_string'
+require 'mongoid-encrypted-fields/fields/unsearchable_encrypted_date'
+require 'mongoid-encrypted-fields/fields/unsearchable_encrypted_date_time'
+require 'mongoid-encrypted-fields/fields/unsearchable_encrypted_time'
 
 module Mongoid
   module EncryptedFields
 
     class << self
       # Set cipher used for all field encryption/decryption
-      attr_accessor :cipher
+      attr_accessor :cipher, :unsearchable_cipher
     end
   end
 end

--- a/lib/mongoid-encrypted-fields/fields/encrypted_string.rb
+++ b/lib/mongoid-encrypted-fields/fields/encrypted_string.rb
@@ -21,6 +21,11 @@ module Mongoid
 
     class << self
 
+      def decrypt(encrypted)
+        s = super
+        s.force_encoding(Encoding::UTF_8) if s
+      end
+
       def convert(object)
         new(object)
       end

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_date.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_date.rb
@@ -1,0 +1,21 @@
+#
+# Used to store an encrypted date in Mongo, using a unique salt, when it is not necessary to find a record by its encrypted value
+#
+# Usage:
+# field :birth_date, type: Mongoid::EncryptedDate
+#
+# Set with an unencrypted date
+# p = Person.new()
+# p.birth_date = Date.new(2000, 1, 1)
+#
+# Get returns the unencrypted date
+# puts p.birth_date -> 'Jan 1, 2000'
+#
+# Use the encrypted property to see the encrypted value
+# puts p.birth_date.encrypted -> '....'
+#
+module Mongoid
+  class UnsearchableEncryptedDate < Mongoid::EncryptedDate
+    include Mongoid::UnsearchableEncryptedField
+  end
+end

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_date_time.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_date_time.rb
@@ -1,0 +1,21 @@
+#
+# Used to store an encrypted datetime in Mongo, using a unique salt, when it is not necessary to find a record by its encrypted value
+#
+# Usage:
+# field :birth_date, type: Mongoid::EncryptedDate
+#
+# Set with an unencrypted date
+# p = Person.new()
+# p.birth_date = Date.new(2000, 1, 1)
+#
+# Get returns the unencrypted date
+# puts p.birth_date -> 'Jan 1, 2000'
+#
+# Use the encrypted property to see the encrypted value
+# puts p.birth_date.encrypted -> '....'
+#
+module Mongoid
+  class UnsearchableEncryptedDateTime < Mongoid::EncryptedDateTime
+    include Mongoid::UnsearchableEncryptedField
+  end
+end

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_field.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_field.rb
@@ -1,0 +1,30 @@
+require 'active_support/concern'
+
+module Mongoid
+  module UnsearchableEncryptedField
+    extend ActiveSupport::Concern
+
+    def unsearchable?
+      true
+    end
+
+    module ClassMethods
+      def encrypt(plaintext)
+        encrypted = EncryptedFields.unsearchable_cipher.encrypt(plaintext).chomp
+        Mongoid::EncryptedField::MARKER + encrypted
+      end
+
+      def decrypt(encrypted)
+        unmarked = encrypted.slice(Mongoid::EncryptedField::MARKER.size..-1)
+        EncryptedFields.unsearchable_cipher.decrypt(unmarked)
+      end
+
+      def unsearchable?
+        true
+      end
+
+    end
+
+  end
+end
+

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_hash.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_hash.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+#
+# Used to store an encrypted hash in Mongo, using a unique salt, when it is not necessary to find a record by its encrypted value
+#
+# Usage:
+# field :address, type: Mongoid::EncryptedHash
+#
+# Set with an unencrypted hash
+# p = Person.new()
+# p.address = {street: "123 Main St", city: "Springdale", state: "MD"}
+#
+# Get returns the unencrypted hash
+# puts p.address -> {'street'=>"123 Main St", 'city'=>"Springdale", 'state'=>"MD"}
+#
+# Note that symbols used as keys are converted to strings (just like using a Hash with Mongo)
+#
+# Use the encrypted property to see the encrypted value
+# puts p.address.encrypted -> '....'
+require 'yaml'
+
+module Mongoid
+  class UnsearchableEncryptedHash < Mongoid::EncryptedHash
+    include Mongoid::UnsearchableEncryptedField
+  end
+end

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_string.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_string.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+#
+# Used to store an encrypted string in Mongo, using a unique salt, when it is not necessary to find a record by its encrypted value
+#
+# Usage:
+# field :social_security_number, type: Mongoid::EncryptedString
+#
+# Set with an unencrypted string
+# p = Person.new()
+# p.social_security_number = '123456789'
+#
+# Get returns the unencrypted string
+# puts p.social_security_number -> '123456789'
+#
+# Use the encrypted property to see the encrypted value
+# puts p.social_security_number.encrypted -> '....'
+#
+module Mongoid
+  class UnsearchableEncryptedString < Mongoid::EncryptedString
+    include Mongoid::UnsearchableEncryptedField
+  end
+end

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_string.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_string.rb
@@ -18,5 +18,14 @@
 module Mongoid
   class UnsearchableEncryptedString < Mongoid::EncryptedString
     include Mongoid::UnsearchableEncryptedField
+
+    class << self
+
+      def decrypt(encrypted)
+        s = super
+        s.force_encoding(Encoding::UTF_8) if s
+      end
+
+    end
   end
 end

--- a/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_time.rb
+++ b/lib/mongoid-encrypted-fields/fields/unsearchable_encrypted_time.rb
@@ -1,0 +1,21 @@
+#
+# Used to store an encrypted time in Mongo, using a unique salt, when it is not necessary to find a record by its encrypted value
+#
+# Usage:
+# field :birth_date, type: Mongoid::EncryptedDate
+#
+# Set with an unencrypted date
+# p = Person.new()
+# p.birth_date = Date.new(2000, 1, 1)
+#
+# Get returns the unencrypted date
+# puts p.birth_date -> 'Jan 1, 2000'
+#
+# Use the encrypted property to see the encrypted value
+# puts p.birth_date.encrypted -> '....'
+#
+module Mongoid
+  class UnseachableEncryptedTime < Mongoid::EncryptedTime
+    include Mongoid::UnsearchableEncryptedField
+  end
+end


### PR DESCRIPTION
In cases where fields don't need to be searchable, we can add an extra layer of security by using unique salts.