### PR TITLE
Fix all_in any_in

### DIFF
--- a/lib/mongoid-encrypted-fields/fields/encrypted_field.rb
+++ b/lib/mongoid-encrypted-fields/fields/encrypted_field.rb
@@ -42,6 +42,8 @@ module Mongoid
       def mongoize(object)
         #EncryptedFields.logger.debug "#{name}##{__method__.to_s}: #{object.inspect}"
         case
+          when object.is_a?(Array)
+            object.map{ |el| mongoize(el) }
           when object.is_a?(self.class)
             object.mongoize
           when object.blank? || is_encrypted?(object)

--- a/spec/mongoid-encrypted-fields/fields/encrypted_field_spec.rb
+++ b/spec/mongoid-encrypted-fields/fields/encrypted_field_spec.rb
@@ -26,5 +26,12 @@ module Mongoid
       Mongoid::EncryptedString.is_encrypted?(unencrypted).should be false
     end
 
+    it "should mongoize an array object" do
+      plaintext = "this is a test!"
+      encrypted = Mongoid::EncryptedString.mongoize([plaintext]).first
+
+      Mongoid::EncryptedString.is_encrypted?(encrypted).should be true
+    end
+
   end
 end


### PR DESCRIPTION
When i use `all_in` or `any_in` methods for encrypted fields i've got this error:
```ruby
User.any_in(email: ["encrypted_email1", "encrypted_email2"])
# TypeError:
#   no implicit conversion of Array into String
```
This PR should fix it.