### PR TITLE
Fix readme usage typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Mongoid 3, Mongoid 4 and Rails 3.2 are supported in version 1.x of this gem.
 ## Usage
 * Configure the cipher to be used for encrypting field values:
 
-    GibberishCipher can be found in examples - uses the [Gibberish](https://github.com/mdp/gibberish) gem:
+    GibberishCipher can be found in the [examples](https://github.com/KoanHealth/mongoid-encrypted-fields/tree/master/examples) - uses the [Gibberish](https://github.com/mdp/gibberish) gem:
 
     ```ruby
-    Mongoid::EncryptedFields.cipher = Gibberish.new(ENV['MY_PASSWORD'], ENV['MY_SALT'])
+    Mongoid::EncryptedFields.cipher = GibberishCipher.new(ENV['MY_PASSWORD'], ENV['MY_SALT'])
     ```
 
 * Use encrypted types for fields in your models:


### PR DESCRIPTION
This was already "fixed" from `GibberishCipher` to `Gibberish` in https://github.com/KoanHealth/mongoid-encrypted-fields/commit/6c3c90a1ca46c0c37e8cbec90b619b073069dc61 but that's a mistake.
The Gibberish gem's `Gibberish` constant is a module, not a class.
Also, the `cipher` attribute expects a cipher object.
The original code example was correct, so this PR reverts to that + adds a link to the examples directory.
